### PR TITLE
Fix/#27

### DIFF
--- a/fastapi_app/app/services/vector_store.py
+++ b/fastapi_app/app/services/vector_store.py
@@ -9,6 +9,14 @@
 """
 
 import os
+
+# chroma 사용 시 python-sqlite3 버전 문제 해결
+# 내장 모듈 sqlite3 대신 pysqlite3 사용
+import sys
+import pysqlite3
+sys.modules["sqlite3"] = pysqlite3
+import sqlite3
+
 from typing import List, Dict, Any, Optional
 from chromadb import Client, Settings
 from chromadb.utils import embedding_functions

--- a/fastapi_app/requirements.txt
+++ b/fastapi_app/requirements.txt
@@ -7,4 +7,5 @@ langchain-google-genai==0.0.5
 google-generativeai==0.3.2
 pydantic-settings==2.1.0
 chromadb==0.4.22
-sentence-transformers==2.2.2 
+sentence-transformers==4.1.0
+huggingface_hub==0.31.1


### PR DESCRIPTION
## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
chroma db 사용을 위한 라이브러리 버전 충돌 해결

## 🔍 변경사항

 <!-- 주요 변경사항 목록 (불릿 포인트) -->

- chroma 사용 시 필요한 python 내장 라이브러리인 sqlite3 버전 충돌 발생
- python 자체 버전이 3.10인경우 낮은 버전 오류
- 3.11 이상인 경우 라이브러리 충돌
- python 내장 sqlite3를 사용하는것이 아닌 pysqlite3를 밭아 사용
- 이전 버전의 경우 sentence-transformers==2.2.2
- huggingface_hub 0.29.0 버전 이후 cached-download 함수 삭제
- 기존 버전의 sentence-transformers 라이브러리와 호환성 문제 발생
- 두 라이브러리를 각각 4.1.0, 0.31.1로 수정

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #27 

