### PR TITLE
Chore/#78

### DIFF
--- a/fastapi_app/main.py
+++ b/fastapi_app/main.py
@@ -38,6 +38,9 @@ app.include_router(api_v1_router, prefix="/api")
 # 요청/응답 로깅 미들웨어
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+        
     start_time = time.time()
     try:
         logger.info(f"요청 시작: {request.method} {request.url}")


### PR DESCRIPTION
- 지속적인 로깅으로 인해 미들웨어 로깅에서 healthcheck endpoint를 제외 #78

## 📝 PR 개요

불필요한 로그가 지속적으로 발생하여 미들웨어 로깅에서 healthcheck endpoint의 경로를 제외하였습니다.

## 🔍 변경사항

- 미들웨어 로깅 내 헬스체크 경로 예외처리

## 🔗 관련 이슈

Closes #78