### PR TITLE
Fix/#88

### DIFF
--- a/fastapi_app/app/services/recommend_engine.py
+++ b/fastapi_app/app/services/recommend_engine.py
@@ -6,7 +6,9 @@
     - RecommendationEngine: 추천 엔진 클래스
 """
 
+import math
 import logging
+
 from typing import Dict, List, Any
 from collections import defaultdict
 from app.services.vector_store import PlaceStore
@@ -83,7 +85,9 @@ class RecommendationEngine:
                             
                         # 유사도 계산 및 점수 누적
                         for meta, dist in zip(results["metadatas"][0], results["distances"][0]):
-                            if not meta or not dist:
+                            if meta is None:
+                                continue
+                            if dist is None or (isinstance(dist, float) and math.isnan(dist)):
                                 continue
                             pid = meta.get("place_id")
                             if not pid:


### PR DESCRIPTION
## 📝 PR 개요

Chroma DB Retriever의 결과 형식은 metadata, distance 두 값을 반환합니다.
결과 값을 반환받아 장소에 대한 유사도로 변환하는 과정에서, Retriever의 결측치를 예외처리하기 위해 아래 코드를 사용했습니다.

```python
for meta, dist in zip(results["metadatas"][0], results["distances"][0]):
    if not meta or not dist:
        continue
```

위 코드에서 문제가 발생했습니다.
Chroma DB의 `query()` 에 사용되는 distance는 두 embedding 간 거리를 의미하는 변수로, 거리가 가까울수록 값이 작아집니다.
만약 두 embedding vector가 동일한 값일 경우, distance가 0이 되어버려 위 코드에서 예외처리가 되는 문제가 지속해서 발생하고 있었고, 이로 인해 검색 성능이 낮아지고 있었습니다.

위 문제를 해결하기 위해 예외처리 과정을 수정하여 distance가 none, nan인 경우만 예외처리 되도록 코드를 수정하였습니다.

## 🔍 변경사항

- distance 예외처리 조건문 수정

## 🔗 관련 이슈

Closes #88