### PR TITLE
chore : Dockerfile 작성

### DIFF
--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -1,0 +1,26 @@
+# Python 3.10 slim 이미지를 베이스로 사용
+FROM python:3.10
+
+# 시스템 패키지 설치
+RUN apt-get update && apt-get install -y build-essential libsqlite3-dev && rm -rf /var/lib/apt/lists/*
+
+# 컨테이너 내 작업 디렉토리 설정
+WORKDIR /app
+
+# 의존성 파일 복사
+COPY requirements.txt ./
+COPY pysqlite3_binary-0.5.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl .
+
+# wheel 설치에 필요한 최소 구성
+RUN pip install --upgrade pip
+
+RUN pip install ./pysqlite3_binary-0.5.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+
+# 의존성 설치
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 소스 코드 전체 복사
+COPY . .
+
+# FastAPI 서버 실행 (main.py의 app 객체 기준)
+CMD ["python3", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]


### PR DESCRIPTION


## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
AI 서버를 도커로 띄우기 위한 Dockerfile 작성

## 🔍 변경사항

 <!-- 주요 변경사항 목록 (불릿 포인트) -->

- AI 서버를 도커로 띄우기 위한 Dockerfile 작성
- pysqlite3-binary 라이브러리가 pip로 설치되지 않는 문제 발생
- pysqlite3-binary는 pip가 아닌 wheel파일을 설치해야 설치가 가능
- 추가적으로 해당 wheel파일은 linux운영체제에서만 빌드가 가능(macos 불가)
- wheel파일 추가 및 dockerfile 작성 완료

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #80 
