### PR TITLE
chore : 콘솔 info log 삭제

### DIFF
--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -23,4 +23,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # FastAPI 서버 실행 (main.py의 app 객체 기준)
-CMD ["python3", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["python3", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--no-access-log"]


### PR DESCRIPTION


## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
ai 서버 실행 시 불필요한 healthcheck 응답에 대한 로그가 남는 현상
인스턴스 램에 과부하를 줄 수 있기 때문에 이를 삭제하여야 함

## 🔍 변경사항

<!-- 주요 변경사항 목록 (불릿 포인트) -->

- fastapi uvicorn의 경우 모든 http 요청에 대한 응답을 콘솔에 표시
- --no-access-log 옵션을 사용하여 콘솔 log를 출력하지 않고 서버를 열도록 함
- Dockerfile의 fastapi 실행 명령어 옵션 추가

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #122

