### PR TITLE
chore : Dockerfile base image 수정

### DIFF
--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -1,5 +1,5 @@
 # Python 3.10 slim 이미지를 베이스로 사용
-FROM python:3.10
+FROM python:3.10-slim
 
 # 시스템 패키지 설치
 RUN apt-get update && apt-get install -y build-essential libsqlite3-dev && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION

## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
Jenkins를 통해 ai 서버 배포 시 이미지가 너무 무거워 빌드시간이 오래걸리는 문제가 발생
서버를 구동하기 위해 필요한 base image인 python 3.10 image를 slim으로 변경하여 크기를 줄이고자 함

## 🔍 변경사항

<!-- 주요 변경사항 목록 (불릿 포인트) -->

- 기존 사용하던 base image python3.10에서 python3.10-slim으로 변경 


## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #126
