### PR TITLE
Deploy: 로그 수집을 위한 jenkinsfile volume 할당

### DIFF
--- a/fastapi_app/Jenkinsfile
+++ b/fastapi_app/Jenkinsfile
@@ -137,6 +137,7 @@ docker pull ${env.GAR_IMAGE}
 
 sudo docker run -d --name ${env.CONTAINER_NAME} \\
   --env-file /home/${env.SSH_USER}/.env \\
+  -v /home/${env.SSH_USER}/logs:/logs \
   -p ${env.PORT}:${env.PORT} \\
   ${env.GAR_IMAGE}
 """


### PR DESCRIPTION
## 📝 PR 개요
로그 수집을 위해 jenkins로 ai를 실행할때 로그 volume을 마운트한다.
## 🔗 관련 이슈
- #129
