### PR TITLE
deploy : cron 시각 변경

### DIFF
--- a/fastapi_app/Jenkinsfile
+++ b/fastapi_app/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                     } else if (branchName == 'dev') {
                         properties([pipelineTriggers([
                             cron('30 3 * * 1-4'),
-                            cron('30 0 * * 5'),
+                            cron('0 1 * * 5'),
                             cron('30 3 * * 6,7')
                         ])])
                     } else {


### PR DESCRIPTION
## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
prod와 dev 환경의 배포가 금요일에 동시에 실행될 경우 Jenkins 서버의 CPU 사용량이 급증하여 성능 저하가 발생하는 문제가 있었습니다. 이를 방지하기 위해 cron 설정을 조정하여 금요일에 두 배포 작업이 겹치지 않도록 시간대를 분리하였습니다.

## 🔍 변경사항

<!-- 주요 변경사항 목록 (불릿 포인트) -->

- Jenkins 파이프라인의 cron 트리거 중 금요일 dev 배포 시간 변경
- 기존: 금요일 오전 9시 30분
- 변경: 금요일 오전 10시 0분
- Jenkins CPU 부하 완화 목적의 시간 분산 적용


## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->


## 🚨 주의사항 (Optional)

<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
