### PR TITLE
feat : Jenkins 파이프라인에서 모델 다운로드 및 Docker 이미지 포함 처리

### DIFF
--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 # 의존성 파일 복사
 COPY requirements.txt ./
 COPY pysqlite3_binary-0.5.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl .
+COPY model /app/model
 
 # wheel 설치에 필요한 최소 구성
 RUN pip install --upgrade pip

--- a/fastapi_app/Jenkinsfile
+++ b/fastapi_app/Jenkinsfile
@@ -117,6 +117,30 @@ pipeline {
             }
         }
 
+        stage('Download Model from GCS') {
+            steps {
+                dir('fastapi_app') {
+                    script {
+                        sh """
+                        gcloud secrets versions access latest \
+                        --secret="jenkins-ssh-key-shared" \
+                        --project="${env.PROJECT_ID}" > jenkins-gcp-key.json
+                        """
+
+                        sh """
+                        gcloud auth activate-service-account --key-file=jenkins-gcp-key.json
+                        gcloud config set project ${env.PROJECT_ID}
+
+                        mkdir -p model
+                        gsutil -m cp -r gs://static-backup-bucket/embedding_model/krsbert_tokenizer model/
+                        gsutil -m cp gs://static-backup-bucket/embedding_model/snunlp_KR-SBERT-V40K-klueNLI-* model/
+                        """
+                    }
+                }
+            }
+        }
+
+
         stage('GAR 인증') {
             steps {
                 sh "gcloud auth configure-docker ${env.GAR_HOST} --quiet"


### PR DESCRIPTION
## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
GCS에 저장된 임베딩 모델을 Jenkins에서 다운로드하여 fastapi_app/model 경로에 저장하고, Dockerfile에 해당 디렉토리를 복사하여 Docker 이미지에 모델을 포함시킵니다. 이를 통해 AI 인스턴스에서는 별도 다운로드 없이 컨테이너 내에서 모델을 직접 사용할 수 있게 됩니다.

## 🔍 변경사항

<!-- 주요 변경사항 목록 (불릿 포인트) -->

- GCP Secret Manager에서 Jenkins용 서비스 계정 키를 다운로드하여 GCS 인증 처리
- fastapi_app/model 경로에 GCS의 임베딩 모델과 토크나이저 파일 다운로드
- Dockerfile 내 COPY model /app/model 명령어를 통해 모델을 Docker 이미지에 포함

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
- 없음.

## 🚨 주의사항 (Optional)

<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
