### PR TITLE
feat : hyperclovax basemodel 로드 구현

### DIFF
--- a/fastapi_app/app/services/clovax_factory.py
+++ b/fastapi_app/app/services/clovax_factory.py
@@ -1,0 +1,31 @@
+import threading
+from transformers import AutoTokenizer, pipeline, AutoModelForCausalLM
+from langchain_community.llms import HuggingFacePipeline
+from app.core.config import settings
+from peft import PeftModel
+
+class ClovaXFactory:
+    _instance = None
+    _lock = threading.Lock()
+
+    @classmethod
+    def _create_instance(cls):
+        model_id = settings.CLOVAX_MODEL_NAME  # 예: "chanhue/dolpin-hyperclova-lora"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        base_model = AutoModelForCausalLM.from_pretrained("naver-hyperclovax/HyperCLOVAX-SEED-Text-Instruct-1.5B")
+        model = PeftModel.from_pretrained(base_model, model_id)
+        hf_pipe = pipeline(
+            "text-generation",
+            model=model,
+            tokenizer=tokenizer,
+            max_new_tokens=256
+        )
+        return HuggingFacePipeline(pipeline=hf_pipe)
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls._create_instance()
+        return cls._instance 


### PR DESCRIPTION


## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
허깅페이스 라이브러리 버전이 최신 버전이 아닌 구버전을 사용함에 있어 lora adapter로 fintuning을 진행한 hyperclovax의 사용을 위해서는 basemodel를 로드하는 과정이 필요
따라서 기존 코드의 모델 선언부를 수정하여 basemodel을 불러올 수 있도록 구현

## 🔍 변경사항

<!-- 주요 변경사항 목록 (불릿 포인트) -->

- peft 라이브러리 도입
- basemodel 로딩 코드 추가

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #215 

## 📸 스크린샷 (Optional)

<img width="740" height="367" alt="image" src="https://github.com/user-attachments/assets/f3550107-cf9b-48c5-ab5d-cb8c5977e312" />

